### PR TITLE
Folder after extract parameter longer

### DIFF
--- a/QSOURCE/RELIC.SQLRPGLE
+++ b/QSOURCE/RELIC.SQLRPGLE
@@ -77,7 +77,7 @@
 
        Dcl-Pi RELIC;
          pZIPLoc      Char(128) Const;
-         pNewDir      Char(50)  Const;
+         pNewDir      Char(128) Const;
          pLib         Char(10)  Const;
          pFetchOption Char(10)  Const;
          pLogOption   Char(10)  Const; //*DSP, *SPOOL
@@ -444,4 +444,4 @@
 
        Dcl-Proc LOG_Close;
          Close QsysPrt;
-       End-Proc; 
+       End-Proc;

--- a/QSOURCE/RELICGET.CMD
+++ b/QSOURCE/RELICGET.CMD
@@ -3,7 +3,7 @@
              CMD        Prompt('Relic Package Download')
              PARM       KWD(PLOC)  TYPE(*CHAR) LEN(128) PROMPT('Source +
                           ZIP')
-             PARM       KWD(pDIR)  TYPE(*CHAR) LEN(50)  PROMPT('Folder +
+             PARM       KWD(pDIR)  TYPE(*CHAR) LEN(128)  PROMPT('Folder +
                           after extract') ALWUNPRT(*NO)
              PARM       KWD(PNAME) TYPE(*CHAR) LEN(10)  PROMPT('Into +
                           *LIB') ALWUNPRT(*NO)


### PR DESCRIPTION
The parameter has been made longer so it can support build files within sub-directories. Effectively, this is to support building projects that are in sub-directories. 